### PR TITLE
Add gel as a valid dsn scheme.

### DIFF
--- a/lib/src/connect_config.dart
+++ b/lib/src/connect_config.dart
@@ -794,9 +794,9 @@ Future<void> parseDSNIntoConfig(
     throw InterfaceError("invalid DSN or instance name: '${dsnString.value}'");
   }
 
-  if (!parsed.isScheme('edgedb')) {
+  if (!parsed.isScheme('edgedb') && !parsed.isScheme('gel')) {
     throw InterfaceError(
-        "invalid DSN: schema is expected to be 'edgedb', got '${parsed.scheme}'");
+        "invalid DSN: schema is expected to be 'gel', got '${parsed.scheme}'");
   }
 
   final searchParams = <String, String>{};

--- a/rstdocs/api.rst
+++ b/rstdocs/api.rst
@@ -12,8 +12,8 @@ API
 
 .. code-block:: dart
 
-    Client createClient(
-      {String? dsn, 
+    Client createClient({ 
+      String? dsn, 
       String? instanceName, 
       String? credentials, 
       String? credentialsFile, 
@@ -30,7 +30,7 @@ API
       TLSSecurity? tlsSecurity, 
       Duration? waitUntilAvailable, 
       ConnectConfig? config, 
-      int? concurrency}
+      int? concurrency, }
     )
 
 Creates a new :ref:`Client <edgedb-dart-Client>` instance with the provided connection options.
@@ -139,9 +139,9 @@ mis-configuration).
 
 .. code-block:: dart
 
-    Future<void> execute(
-      String query, 
-      [dynamic args]
+    Future<void> execute( 
+      String query, [
+      dynamic args]
     )
 
 Executes a query, returning no result.
@@ -157,9 +157,9 @@ For details on ``args`` see the ``edgedb`` library
 
 .. code-block:: dart
 
-    Future<List> query(
-      String query, 
-      [dynamic args]
+    Future<List> query( 
+      String query, [
+      dynamic args]
     )
 
 Executes a query, returning a ``List`` of results.
@@ -175,9 +175,9 @@ For details on result types and ``args`` see the ``edgedb`` library
 
 .. code-block:: dart
 
-    Future<String> queryJSON(
-      String query, 
-      [dynamic args]
+    Future<String> queryJSON( 
+      String query, [
+      dynamic args]
     )
 
 Executes a query, returning the result as a JSON encoded ``String``.
@@ -193,9 +193,9 @@ For details on ``args`` see the ``edgedb`` library
 
 .. code-block:: dart
 
-    Future queryRequiredSingle(
-      String query, 
-      [dynamic args]
+    Future queryRequiredSingle( 
+      String query, [
+      dynamic args]
     )
 
 Executes a query, returning a single (non-``null``) result.
@@ -215,9 +215,9 @@ For details on result types and ``args`` see the ``edgedb`` library
 
 .. code-block:: dart
 
-    Future<String> queryRequiredSingleJSON(
-      String query, 
-      [dynamic args]
+    Future<String> queryRequiredSingleJSON( 
+      String query, [
+      dynamic args]
     )
 
 Executes a query, returning the result as a JSON encoded ``String``.
@@ -237,9 +237,9 @@ For details on ``args`` see the ``edgedb`` library
 
 .. code-block:: dart
 
-    Future querySingle(
-      String query, 
-      [dynamic args]
+    Future querySingle( 
+      String query, [
+      dynamic args]
     )
 
 Executes a query, returning a single (possibly ``null``) result.
@@ -258,9 +258,9 @@ For details on result types and ``args`` see the ``edgedb`` library
 
 .. code-block:: dart
 
-    Future<String> querySingleJSON(
-      String query, 
-      [dynamic args]
+    Future<String> querySingleJSON( 
+      String query, [
+      dynamic args]
     )
 
 Executes a query, returning the result as a JSON encoded ``String``.
@@ -292,8 +292,8 @@ for any running queries to finish.
 
 .. code-block:: dart
 
-    Future<T> transaction<T>(
-      Future<T> action(Transaction)
+    Future<T> transaction<T>( 
+      Future<T> action( Transaction)
     )
 
 Execute a retryable transaction.
@@ -338,7 +338,7 @@ with :ref:`withRetryOptions() <edgedb-dart-Client-withRetryOptions>`.
 
 .. code-block:: dart
 
-    Client withConfig(
+    Client withConfig( 
       Map<String, Object> config
     )
 
@@ -360,7 +360,7 @@ configuration parameters refer to the
 
 .. code-block:: dart
 
-    Client withGlobals(
+    Client withGlobals( 
       Map<String, dynamic> globals
     )
 
@@ -389,7 +389,7 @@ Example:
 
 .. code-block:: dart
 
-    Client withModuleAliases(
+    Client withModuleAliases( 
       Map<String, String> aliases
     )
 
@@ -421,7 +421,7 @@ Example:
 
 .. code-block:: dart
 
-    Client withRetryOptions(
+    Client withRetryOptions( 
       RetryOptions options
     )
 
@@ -435,7 +435,7 @@ Returns a new :ref:`Client <edgedb-dart-Client>` instance with the specified :re
 
 .. code-block:: dart
 
-    Client withSession(
+    Client withSession( 
       Session session
     )
 
@@ -453,7 +453,7 @@ methods for convenience.
 
 .. code-block:: dart
 
-    Client withTransactionOptions(
+    Client withTransactionOptions( 
       TransactionOptions options
     )
 
@@ -475,10 +475,10 @@ Manages all options (:ref:`RetryOptions <edgedb-dart-RetryOptions>`, :ref:`Trans
 
 .. code-block:: dart
 
-    Options(
-      {RetryOptions? retryOptions, 
+    Options({ 
+      RetryOptions? retryOptions, 
       TransactionOptions? transactionOptions, 
-      Session? session}
+      Session? session, }
     )
 
 
@@ -535,7 +535,7 @@ Creates a new :ref:`Options <edgedb-dart-Options>` object with all options set t
 
 .. code-block:: dart
 
-    Options withRetryOptions(
+    Options withRetryOptions( 
       RetryOptions options
     )
 
@@ -549,7 +549,7 @@ Returns a new :ref:`Options <edgedb-dart-Options>` object with the specified :re
 
 .. code-block:: dart
 
-    Options withSession(
+    Options withSession( 
       Session session
     )
 
@@ -563,7 +563,7 @@ Returns a new :ref:`Options <edgedb-dart-Options>` object with the specified :re
 
 .. code-block:: dart
 
-    Options withTransactionOptions(
+    Options withTransactionOptions( 
       TransactionOptions options
     )
 
@@ -585,11 +585,11 @@ to be used when executing a query.
 
 .. code-block:: dart
 
-    Session(
-      {String module = 'default', 
+    Session({ 
+      String module = 'default', 
       Map<String, String>? moduleAliases, 
       Map<String, Object>? config, 
-      Map<String, dynamic>? globals}
+      Map<String, dynamic>? globals, }
     )
 
 Creates a new :ref:`Session <edgedb-dart-Session>` object with the given options.
@@ -660,7 +660,7 @@ Creates a new :ref:`Session <edgedb-dart-Session>` with all options set to their
 
 .. code-block:: dart
 
-    Session withConfig(
+    Session withConfig( 
       Map<String, Object> config
     )
 
@@ -682,7 +682,7 @@ configuration parameters refer to the
 
 .. code-block:: dart
 
-    Session withGlobals(
+    Session withGlobals( 
       Map<String, dynamic> globals
     )
 
@@ -701,7 +701,7 @@ Equivalent to using the ``set global`` command.
 
 .. code-block:: dart
 
-    Session withModuleAliases(
+    Session withModuleAliases( 
       Map<String, String> aliases
     )
 
@@ -736,9 +736,9 @@ which override the default for given error conditions.
 
 .. code-block:: dart
 
-    RetryOptions(
-      {int? attempts, 
-      BackoffFunction? backoff}
+    RetryOptions({ 
+      int? attempts, 
+      BackoffFunction? backoff, }
     )
 
 Creates a new :ref:`RetryOptions <edgedb-dart-RetryOptions>` object, with a default `RetryRule <https://pub.dev/documentation/edgedb/latest/edgedb/RetryRule-class.html>`__, with
@@ -778,10 +778,10 @@ Creates a new :ref:`RetryOptions <edgedb-dart-RetryOptions>` with all options se
 
 .. code-block:: dart
 
-    RetryOptions withRule(
-      {required RetryCondition condition, 
+    RetryOptions withRule({ 
+      required RetryCondition condition, 
       int? attempts, 
-      BackoffFunction? backoff}
+      BackoffFunction? backoff, }
     )
 
 Adds a new `RetryRule <https://pub.dev/documentation/edgedb/latest/edgedb/RetryRule-class.html>`__ with the given ``attempts`` and ``backoff`` function,
@@ -809,10 +809,10 @@ For more details on transaction modes see the
 
 .. code-block:: dart
 
-    TransactionOptions(
-      {IsolationLevel? isolation, 
+    TransactionOptions({ 
+      IsolationLevel? isolation, 
       bool? readonly, 
-      bool? deferrable}
+      bool? deferrable, }
     )
 
 Creates a new :ref:`TransactionOptions <edgedb-dart-TransactionOptions>` object with the given ``isolation``,

--- a/rstdocs/client.rst
+++ b/rstdocs/client.rst
@@ -74,43 +74,43 @@ in parentheses are also valid for query parameters):
   * - EdgeDB type
     - Dart type
   * - Sets
-    - `List\<dynamic\> <https://api.dart.dev/stable/3.4.4/dart-core/List-class.html>`__
+    - `List\<dynamic\> <https://api.dart.dev/stable/3.5.4/dart-core/List-class.html>`__
   * - Arrays
-    - `List\<dynamic\> <https://api.dart.dev/stable/3.4.4/dart-core/List-class.html>`__
+    - `List\<dynamic\> <https://api.dart.dev/stable/3.5.4/dart-core/List-class.html>`__
   * - Objects
-    - `Map\<String, dynamic\> <https://api.dart.dev/stable/3.4.4/dart-core/Map-class.html>`__
+    - `Map\<String, dynamic\> <https://api.dart.dev/stable/3.5.4/dart-core/Map-class.html>`__
   * - Tuples (``tuple<x, y, ...>``)
-    - `List\<dynamic\> <https://api.dart.dev/stable/3.4.4/dart-core/List-class.html>`__
+    - `List\<dynamic\> <https://api.dart.dev/stable/3.5.4/dart-core/List-class.html>`__
   * - Named tuples (``tuple<foo: x, bar: y, ...>``)
-    - `Map\<String, dynamic\> <https://api.dart.dev/stable/3.4.4/dart-core/Map-class.html>`__
+    - `Map\<String, dynamic\> <https://api.dart.dev/stable/3.5.4/dart-core/Map-class.html>`__
   * - Ranges
     - :ref:`Range\<dynamic\> <edgedb-dart-Range>`
   * - Multiranges
     - :ref:`MultiRange\<dynamic\> <edgedb-dart-MultiRange>`
   * - Enums
-    - `String <https://api.dart.dev/stable/3.4.4/dart-core/String-class.html>`__
+    - `String <https://api.dart.dev/stable/3.5.4/dart-core/String-class.html>`__
   * - ``str``
-    - `String <https://api.dart.dev/stable/3.4.4/dart-core/String-class.html>`__
+    - `String <https://api.dart.dev/stable/3.5.4/dart-core/String-class.html>`__
   * - ``bool``
-    - `bool <https://api.dart.dev/stable/3.4.4/dart-core/bool-class.html>`__
+    - `bool <https://api.dart.dev/stable/3.5.4/dart-core/bool-class.html>`__
   * - ``int16``/``int32``/``int64``
-    - `int <https://api.dart.dev/stable/3.4.4/dart-core/int-class.html>`__
+    - `int <https://api.dart.dev/stable/3.5.4/dart-core/int-class.html>`__
   * - ``float32``/``float64``
-    - `double <https://api.dart.dev/stable/3.4.4/dart-core/double-class.html>`__
+    - `double <https://api.dart.dev/stable/3.5.4/dart-core/double-class.html>`__
   * - ``json``
     - as decoded by ``json.decode()``
   * - ``uuid``
-    - `String <https://api.dart.dev/stable/3.4.4/dart-core/String-class.html>`__
+    - `String <https://api.dart.dev/stable/3.5.4/dart-core/String-class.html>`__
   * - ``bigint``
-    - `BigInt <https://api.dart.dev/stable/3.4.4/dart-core/BigInt-class.html>`__
+    - `BigInt <https://api.dart.dev/stable/3.5.4/dart-core/BigInt-class.html>`__
   * - ``decimal``
     - *(unsupported)*
   * - ``bytes``
-    - `Uint8List <https://api.dart.dev/stable/3.4.4/dart-typed_data/Uint8List-class.html>`__
+    - `Uint8List <https://api.dart.dev/stable/3.5.4/dart-typed_data/Uint8List-class.html>`__
   * - ``datetime``
-    - `DateTime <https://api.dart.dev/stable/3.4.4/dart-core/DateTime-class.html>`__
+    - `DateTime <https://api.dart.dev/stable/3.5.4/dart-core/DateTime-class.html>`__
   * - ``duration``
-    - `Duration <https://api.dart.dev/stable/3.4.4/dart-core/Duration-class.html>`__
+    - `Duration <https://api.dart.dev/stable/3.5.4/dart-core/Duration-class.html>`__
   * - ``cal::local_datetime``
     - `LocalDateTime <https://pub.dev/documentation/edgedb/latest/edgedb/LocalDateTime-class.html>`__
   * - ``cal::local_date``
@@ -124,7 +124,7 @@ in parentheses are also valid for query parameters):
   * - ``cfg::memory``
     - :ref:`ConfigMemory <edgedb-dart-ConfigMemory>`
   * - ``ext::pgvector::vector``
-    - `Float32List <https://api.dart.dev/stable/3.4.4/dart-typed_data/Float32List-class.html>`__ (`List\<double\> <https://api.dart.dev/stable/3.4.4/dart-core/List-class.html>`__)
+    - `Float32List <https://api.dart.dev/stable/3.5.4/dart-typed_data/Float32List-class.html>`__ (`List\<double\> <https://api.dart.dev/stable/3.5.4/dart-core/List-class.html>`__)
 
 Custom types
 ------------

--- a/rstdocs/datatypes.rst
+++ b/rstdocs/datatypes.rst
@@ -38,11 +38,11 @@ as the result of some operation on a range.
 
 .. code-block:: dart
 
-    Range<T>(
+    Range<T>( 
       T? lower, 
-      T? upper, 
-      {bool? incLower, 
-      bool? incUpper}
+      T? upper, {
+      bool? incLower, 
+      bool? incUpper, }
     )
 
 Creates a new :ref:`Range <edgedb-dart-Range>`.
@@ -144,13 +144,13 @@ The upper boundary of the range, if it exists.
 
 .. code-block:: dart
 
-    int compareTo(
+    int compareTo( 
       Range<T> other
     )
 
 Compares this object to another object.
 
-Returns a value like a `Comparator <https://api.dart.dev/stable/3.4.4/dart-core/Comparator.html>`__ when comparing ``this`` to ``other``.
+Returns a value like a `Comparator <https://api.dart.dev/stable/3.5.4/dart-core/Comparator.html>`__ when comparing ``this`` to ``other``.
 That is, it returns a negative integer if ``this`` is ordered before ``other``,
 a positive integer if ``this`` is ordered after ``other``,
 and zero if ``this`` and ``other`` are ordered together.
@@ -165,7 +165,7 @@ The ``other`` argument must be a value that is comparable to this object.
 
 .. code-block:: dart
 
-    bool contains(
+    bool contains( 
       T element
     )
 
@@ -179,7 +179,7 @@ Checks whether ``element`` is within this range.
 
 .. code-block:: dart
 
-    bool containsRange(
+    bool containsRange( 
       Range<T> range
     )
 
@@ -193,7 +193,7 @@ Checks whether ``range`` is entirely within this range.
 
 .. code-block:: dart
 
-    bool overlaps(
+    bool overlaps( 
       Range<T> other
     )
 
@@ -233,8 +233,8 @@ boundaries by ``()``. If the range is empty, returns the string ``'empty'``.
 
 .. code-block:: dart
 
-    Iterable<T> unpack(
-      {Object? step}
+    Iterable<T> unpack({ 
+      Object? step, }
     )
 
 If the range is discrete and no ``step`` is provided, returns an ``Iterable``
@@ -254,7 +254,7 @@ non-discrete ranges.
 
 .. code-block:: dart
 
-    Range<T> operator *(
+    Range<T> operator *( 
       Range<T> other
     )
 
@@ -268,7 +268,7 @@ Returns the intersection of two ranges.
 
 .. code-block:: dart
 
-    Range<T> operator +(
+    Range<T> operator +( 
       Range<T> other
     )
 
@@ -284,7 +284,7 @@ Throws an error if the result is not a single continuous range.
 
 .. code-block:: dart
 
-    Range<T> operator -(
+    Range<T> operator -( 
       Range<T> other
     )
 
@@ -300,7 +300,7 @@ Throws an error if the result is not a single continuous range.
 
 .. code-block:: dart
 
-    bool operator <(
+    bool operator <( 
       Range<T> other
     )
 
@@ -320,7 +320,7 @@ lower/greater than specified lower/upper bounds respectively.
 
 .. code-block:: dart
 
-    bool operator <=(
+    bool operator <=( 
       Range<T> other
     )
 
@@ -340,7 +340,7 @@ lower/greater than specified lower/upper bounds respectively.
 
 .. code-block:: dart
 
-    bool operator ==(
+    bool operator ==( 
       Object other
     )
 
@@ -354,7 +354,7 @@ Returns whether two ranges are equal.
 
 .. code-block:: dart
 
-    bool operator >(
+    bool operator >( 
       Range<T> other
     )
 
@@ -374,7 +374,7 @@ lower/greater than specified lower/upper bounds respectively.
 
 .. code-block:: dart
 
-    bool operator >=(
+    bool operator >=( 
       Range<T> other
     )
 
@@ -399,7 +399,7 @@ lower/greater than specified lower/upper bounds respectively.
 
 .. code-block:: dart
 
-    MultiRange<T>(
+    MultiRange<T>( 
       Iterable<Range<T>> ranges
     )
 
@@ -441,7 +441,7 @@ but must be consistent between changes to the set.
 
     int get length
 
-The number of elements in :ref:`this <edgedb-dart-MultiRange>`.
+The number of elements in this `Iterable <https://api.dart.dev/stable/3.5.4/dart-core/Iterable-class.html>`__.
 
 Counting all elements may involve iterating through all elements and can
 therefore be slow.
@@ -456,7 +456,7 @@ These *must* override the default implementation of ``length``.
 
 .. code-block:: dart
 
-    bool add(
+    bool add( 
       Range<T> value
     )
 
@@ -495,7 +495,7 @@ Example:
 
 .. code-block:: dart
 
-    bool contains(
+    bool contains( 
       Object? element
     )
 
@@ -515,7 +515,7 @@ Whether ``value`` is in the set.
 
 .. code-block:: dart
 
-    Range<T>? lookup(
+    Range<T>? lookup( 
       Object? element
     )
 
@@ -548,7 +548,7 @@ set element.
 
 .. code-block:: dart
 
-    bool remove(
+    bool remove( 
       Object? value
     )
 
@@ -585,7 +585,7 @@ The method has no effect if ``value`` was not in the set.
 
     Set<Range<T>> toSet()
 
-Creates a `Set <https://api.dart.dev/stable/3.4.4/dart-core/Set-class.html>`__ with the same elements and behavior as this ``Set``.
+Creates a `Set <https://api.dart.dev/stable/3.5.4/dart-core/Set-class.html>`__ with the same elements and behavior as this ``Set``.
 
 The returned set behaves the same as this set
 with regard to adding and removing elements.
@@ -606,7 +606,7 @@ the returned set will have the same order.
 A string representation of this object.
 
 Some classes have a default textual representation,
-often paired with a static ``parse`` function (like `int.parse <https://api.dart.dev/stable/3.4.4/dart-core/int/parse.html>`__).
+often paired with a static ``parse`` function (like `int.parse <https://api.dart.dev/stable/3.5.4/dart-core/int/parse.html>`__).
 These classes will provide the textual representation as
 their string representation.
 
@@ -624,7 +624,7 @@ mainly for debugging or logging.
 
 .. code-block:: dart
 
-    bool operator ==(
+    bool operator ==( 
       Object other
     )
 
@@ -648,7 +648,7 @@ ambiguous 'kB', which can mean 1000 or 1024 bytes.
 
 .. code-block:: dart
 
-    ConfigMemory(
+    ConfigMemory( 
       int _bytes
     )
 
@@ -661,7 +661,7 @@ ambiguous 'kB', which can mean 1000 or 1024 bytes.
 
 .. code-block:: dart
 
-    ConfigMemory.parse(
+    ConfigMemory.parse( 
       String mem
     )
 
@@ -745,7 +745,7 @@ ambiguous 'kB', which can mean 1000 or 1024 bytes.
 A string representation of this object.
 
 Some classes have a default textual representation,
-often paired with a static ``parse`` function (like `int.parse <https://api.dart.dev/stable/3.4.4/dart-core/int/parse.html>`__).
+often paired with a static ``parse`` function (like `int.parse <https://api.dart.dev/stable/3.5.4/dart-core/int/parse.html>`__).
 These classes will provide the textual representation as
 their string representation.
 

--- a/rstdocs/index.rst
+++ b/rstdocs/index.rst
@@ -1,4 +1,5 @@
-.. _edgedb-dart-intro:
+.. edb:tag:: dart
+  .. _edgedb-dart-intro:
 
 Dart client library for EdgeDB
 ==============================

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -610,7 +610,7 @@ void main() {
       select (dt, datetime_get(dt, 'epochseconds') * 1000)
     ''');
       expect(
-          (res[0] as DateTime).millisecondsSinceEpoch, (res[1] as num).ceil());
+          (res[0] as DateTime).millisecondsSinceEpoch, (res[1] as num).floor());
     } finally {
       await client.close();
     }

--- a/test/range_test.dart
+++ b/test/range_test.dart
@@ -1531,7 +1531,7 @@ void main() {
         u.subtract(Duration(days: 1)),
         u,
         u.add(Duration(days: 1)),
-        DateTime(275760, 09, 13)
+        DateTime(275760, 09, 12)
       ];
 
       expect(ranges.map((range) => elements.map((el) => range.contains(el))), [
@@ -1638,7 +1638,7 @@ void main() {
       final l = DateTime(2022, 08, 30);
       final u = DateTime(2022, 09, 02);
       final min = DateTime(-271821, 04, 21);
-      final max = DateTime(275760, 09, 13);
+      final max = DateTime(275760, 09, 12);
 
       final ranges = <Range<DateTime>>[
         Range(l, u, incLower: true, incUpper: false),


### PR DESCRIPTION
test errors caused by:
- a number that exceeds the allowed `DateTime` max, and
- `ceil` on a negative number instead of `floor`
- docs not being updated